### PR TITLE
bug(layer): fix dependency on context

### DIFF
--- a/layer/layer.go
+++ b/layer/layer.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"sync"
 
-	"gopkg.in/vinxi/context.v0"
+	"gopkg.in/vinxi/vinxi.v0/context"
 )
 
 const (


### PR DESCRIPTION
Somehow the `layer` package still depended on the `context.v0` package instead of `vinxi.v0/context` package therefore preventing vinxi from compiling.