### PR TITLE
bug(travis): add missing dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,7 @@ go:
   - tip
 
 before_install:
-  - go get -u github.com/nbio/st
-  - go get -u gopkg.in/vinxi/vinxi.v0
-  - go get -u -v github.com/axw/gocov/gocov
-  - go get -u -v github.com/mattn/goveralls
-  - go get -u -v github.com/golang/lint/golint
+  - go get -t ./...
 
 script:
   - diff -u <(echo -n) <(gofmt -s -d ./)


### PR DESCRIPTION
I'm not sure if that's the best/recommended way to get dependencies though. That should fix all tests issues except for the race condition in `forward` package.