### PR TITLE
fix(test): fix race conditions in Forward tests

### DIFF
--- a/forward/forward_test.go
+++ b/forward/forward_test.go
@@ -160,9 +160,11 @@ func (s *FwdSuite) TestCustomRewriter(c *C) {
 }
 
 func (s *FwdSuite) TestCustomTransportTimeout(c *C) {
+	done := make(chan bool)
 	srv := testutils.NewHandler(func(w http.ResponseWriter, req *http.Request) {
 		time.Sleep(20 * time.Millisecond)
 		w.Write([]byte("hello"))
+		done <- true
 	})
 	defer srv.Close()
 
@@ -179,6 +181,7 @@ func (s *FwdSuite) TestCustomTransportTimeout(c *C) {
 	defer proxy.Close()
 
 	re, _, err := testutils.Get(proxy.URL)
+	<-done
 	c.Assert(err, IsNil)
 	c.Assert(re.StatusCode, Equals, http.StatusGatewayTimeout)
 }


### PR DESCRIPTION
The reason why we had race conditions is that we have a server waiting
20 ms. The proxy called this server and closed the connection after 5
ms, allowing the test to finish. Once the test was finished, the
server was still sleeping/waiting to end the request processing but
was closed by the main routine before it was able to finish
processing.